### PR TITLE
Add possibility to rollup services with a matching names in nodeGraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Next
+
+- Add support for rolling up kuma services inside the same node in the nodeGraph.
+  This feature is especially useful when services have multiple inbounds and the default will always rollup k8s services together.
+
 ## 0.0.4
 
 - Add services query type

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -40,7 +40,7 @@ export function ConfigEditor(props: Props) {
       <FieldSet label="Secondary datasource">
         <InlineField
           label="Prometheus datasource"
-          tooltip="The prometheus datasource to extract stats from (this datasource will proxy some requests throuhg this datasource)"
+          tooltip="The prometheus datasource to extract stats from (this datasource will proxy some requests through this datasource)"
         >
           <Select
             options={allDatasources}

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,7 +1,7 @@
 import { defaults, map } from 'lodash';
 
-import React from 'react';
-import { AsyncSelect, InlineField, InlineFieldRow, Select } from '@grafana/ui';
+import React, { ChangeEvent } from 'react';
+import { AsyncSelect, InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
 
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 
@@ -64,6 +64,19 @@ export function QueryEditor(props: Props) {
           onChange={(entry: SelectableValue<string>) => {
             props.onChange({ ...query, zone: entry.value || '' });
           }}
+        />
+      </InlineField>,
+      <InlineField
+        key="rollupRegexp"
+        label="rollupRegexp"
+        tooltip={`a regular expression to rollup all services of the same name, all matching services will be rolled up in the first regular expression group. For example the default value: ${defaultQuery.rollupRegEx} rolls all <service>_<namespace>_svc_<port> into <service>_<namespace>`}
+      >
+        <Input
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            props.onChange({ ...props.query, rollupRegEx: event.target.value });
+          }}
+          css=""
+          value={props.query.rollupRegEx || ''}
         />
       </InlineField>
     );

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -153,6 +153,7 @@ export class DataSource extends DataSourceWithBackend<KumaQuery, KumaDataSourceO
     }
     const mesh = getTemplateSrv().replace(request.targets[0].mesh, request.scopedVars);
     const zone = getTemplateSrv().replace(request.targets[0].zone, request.scopedVars);
+    const rollup = getTemplateSrv().replace(request.targets[0].rollupRegEx, request.scopedVars);
     // Add a bunch
     let selector = `mesh="${mesh}",envoy_cluster_name!~"^localhost_[0-9]+$",envoy_cluster_name!="ads_cluster",envoy_cluster_name!="kuma_envoy_admin"`;
     if (zone) {
@@ -160,7 +161,7 @@ export class DataSource extends DataSourceWithBackend<KumaQuery, KumaDataSourceO
     }
     try {
       let stats = await this.postResource('services', { mesh: mesh }).then((r) => {
-        const out = new Stats();
+        const out = new Stats(new RegExp(rollup));
         for (let s of r.services) {
           out.addNode(s);
         }

--- a/src/stats.test.ts
+++ b/src/stats.test.ts
@@ -118,3 +118,141 @@ test('processEdgePromQueries', () => {
   expect(stats.nodeStats['srv3'].edges['srv2']).toBeTruthy();
   expect(stats.nodeStats['srv4'].edges).toEqual({});
 });
+
+test('with rollup', () => {
+  const stats = new Stats(/(.+)(_srv_[0-9]+)/);
+  const srvs = [
+    { name: 'srv1_srv_1', status: 'online', online: 3, offline: 0, total: 3 },
+    { name: 'srv1_srv_2', status: 'online', online: 3, offline: 0, total: 3 },
+    { name: 'srv3_srv_1', status: 'online', online: 1, offline: 0, total: 1 },
+    { name: 'srv4', status: 'online', online: 1, offline: 0, total: 1 },
+  ];
+  for (const srv of srvs) {
+    stats.addNode(srv);
+  }
+  const status = [
+    {
+      metric: { envoy_cluster_name: 'srv1_srv_1', envoy_response_code_class: '2' },
+      value: [1631800504.203, '245'],
+    },
+    {
+      metric: { envoy_cluster_name: 'srv1_srv_2', envoy_response_code_class: '2' },
+      value: [1631800504.203, '363'],
+    },
+    {
+      metric: { envoy_cluster_name: 'srv3_srv_1', envoy_response_code_class: '2' },
+      value: [1631800504.203, '189'],
+    },
+    {
+      metric: { envoy_cluster_name: 'srv1_srv_1', envoy_response_code_class: '5' },
+      value: [1631800504.203, '180'],
+    },
+  ];
+  const rps = [
+    { metric: { envoy_cluster_name: 'srv1_srv_1' }, value: [1631800504.203, '0.5777777777777777'] },
+    { metric: { envoy_cluster_name: 'srv1_srv_2' }, value: [1631800504.203, '13.066666666666668'] },
+    { metric: { envoy_cluster_name: 'srv3_srv_1' }, value: [1631800504.203, '0.6000000000000001'] },
+  ];
+  const lat50 = [
+    { metric: { envoy_cluster_name: 'srv1_srv_1' }, value: [1631800504.203, '3'] },
+    { metric: { envoy_cluster_name: 'srv1_srv_2' }, value: [1631800504.203, '4'] },
+    { metric: { envoy_cluster_name: 'srv3_srv_1' }, value: [1631800504.203, 'NaN'] },
+    { metric: { envoy_cluster_name: 'srv4' }, value: [1631800504.203, 'NaN'] },
+    { metric: { envoy_cluster_name: 'srv5_srv_1' }, value: [1631800504.203, 'NaN'] },
+  ];
+  const lat99 = [
+    { metric: { envoy_cluster_name: 'srv1_srv_1' }, value: [1631800504.203, '10'] },
+    { metric: { envoy_cluster_name: 'srv1_srv_2' }, value: [1631800504.203, '50'] },
+    { metric: { envoy_cluster_name: 'srv3_srv_1' }, value: [1631800504.203, 'NaN'] },
+    { metric: { envoy_cluster_name: 'srv4' }, value: [1631800504.203, 'NaN'] },
+    { metric: { envoy_cluster_name: 'srv5_srv_1' }, value: [1631800504.203, 'NaN'] },
+  ];
+  processServicePromQueries(stats, status, rps, lat50, lat99);
+
+  const status2 = [
+    {
+      metric: { envoy_cluster_name: 'srv1_srv_1', envoy_response_code_class: '2', kuma_io_service: 'srv1_srv_2' },
+      value: [1631800504.203, '179'],
+    },
+    {
+      metric: { envoy_cluster_name: 'srv1_srv_1', envoy_response_code_class: '2', kuma_io_service: 'srv4' },
+      value: [1631800504.203, '179'],
+    },
+    {
+      metric: { envoy_cluster_name: 'srv3_srv_1', envoy_response_code_class: '2', kuma_io_service: 'srv1_srv_2' },
+      value: [1631800504.203, '182'],
+    },
+  ];
+  const rps2 = [
+    {
+      metric: { envoy_cluster_name: 'srv1_srv_1', kuma_io_service: 'srv1_srv_2' },
+      value: [1631800504.203, '3'],
+    },
+    {
+      metric: { envoy_cluster_name: 'srv1_srv_1', kuma_io_service: 'srv4' },
+      value: [1631800504.203, '4'],
+    },
+    {
+      metric: { envoy_cluster_name: 'srv3_srv_1', kuma_io_service: 'srv1_srv_2' },
+      value: [1631800504.203, '10'],
+    },
+  ];
+  const lat502 = [
+    {
+      metric: { envoy_cluster_name: 'srv1_srv_1', kuma_io_service: 'srv1_srv_2' },
+      value: [1631800504.203, '3'],
+    },
+    {
+      metric: { envoy_cluster_name: 'srv1_srv_1', kuma_io_service: 'srv4' },
+      value: [1631800504.203, '4'],
+    },
+    {
+      metric: { envoy_cluster_name: 'srv3_srv_1', kuma_io_service: 'srv1_srv_1' },
+      value: [1631800504.203, 'NaN'],
+    },
+  ];
+  const lat992 = [
+    {
+      metric: { envoy_cluster_name: 'srv1_srv_1', kuma_io_service: 'srv1_srv_2' },
+      value: [1631800504.203, '10'],
+    },
+    {
+      metric: { envoy_cluster_name: 'srv1_srv_1', kuma_io_service: 'srv4' },
+      value: [1631800504.203, '20'],
+    },
+    {
+      metric: { envoy_cluster_name: 'srv3_srv_1', kuma_io_service: 'srv1_srv_2' },
+      value: [1631800504.203, 'NaN'],
+    },
+    {
+      metric: { envoy_cluster_name: 'srv3_srv_1', kuma_io_service: 'srv1_srv_2' },
+      value: [1631800504.203, 2],
+    },
+  ];
+  processEdgePromQueries(stats, status2, rps2, lat502, lat992);
+  expect(stats.sends).toEqual({ srv1: true });
+  expect(stats.nodeStats['srv1'].statuses).toEqual({ s2xx: 245 + 363, s3xx: 0, s4xx: 0, s5xx: 180 });
+  expect(stats.nodeStats['srv3'].statuses).toEqual({ s2xx: 189, s3xx: 0, s4xx: 0, s5xx: 0 });
+  expect(stats.nodeStats['srv4']).toBeUndefined();
+  expect(stats.nodeStats['srv5']).toBeUndefined();
+  expect(stats.nodeStats['srv1'].edges).toEqual({
+    srv1: {
+      dest: 'srv1',
+      latencyp50: 3,
+      latencyp99: 10,
+      rps: 3,
+      src: 'srv1',
+      statuses: { s2xx: 179, s3xx: 0, s4xx: 0, s5xx: 0 },
+    },
+  });
+  expect(stats.nodeStats['srv3'].edges).toEqual({
+    srv1: {
+      dest: 'srv3',
+      latencyp50: 0,
+      latencyp99: 2,
+      rps: 10,
+      src: 'srv1',
+      statuses: { s2xx: 182, s3xx: 0, s4xx: 0, s5xx: 0 },
+    },
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import { DataQuery, DataSourceJsonData } from '@grafana/data';
 export interface KumaQuery extends DataQuery {
   mesh: string;
   zone?: string;
+  rollupRegEx?: string;
 }
 
 export const MeshGraphQType = 'mesh-graph';
@@ -13,6 +14,7 @@ export const queryTypes = [MeshGraphQType, ZonesQType, MeshesQType, ServicesQTyp
 
 export const defaultQuery: Partial<KumaQuery> = {
   queryType: MeshesQType,
+  rollupRegEx: '(.*)(_svc(_[0-9]+)?)',
 };
 
 /**


### PR DESCRIPTION
This is useful when a service has multiple inbounds as it will group
together all stats on a single node in the nodeGraph which is more readable

Signed-off-by: Charly Molter <charly.molter@konghq.com>