### PR TITLE
docs(observability): update docs after consolidating metrics, logs, traces into observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Add to the datasource configuration:
 
 #### kumactl >= 1.7.0
 
-If you use `kumactl install observability --components grafana,prometheus` with a version of kumactl >= 1.7.0 the plugin will be setup automatically.
+If you use `kumactl install observability` with a version of kumactl >= 1.7.0 the plugin will be setup automatically.
 
 #### kumactl 1.3.0-1.6.*
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ Once this is done you can go in `explore` and pick the kuma-datasource with the 
 
 Add to the datasource configuration:
 
+#### kuma >= 1.7.0
+
+```yaml
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://prometheus-server.mesh-observability
+      - name: Kuma
+        type: kumahq-kuma-datasource
+        url: http://kuma-control-plane.kuma-system:5681
+        jsonData:
+          prometheusDataSourceId: "1"
+```
+
+#### kuma < 1.7.0
+
 ```yaml
     datasources:
       - name: Prometheus
@@ -51,7 +68,13 @@ Add to the datasource configuration:
 
 ### With `kumactl`
 
-If you use `kumactl install metrics` with a version of kumactl >= 1.3.0 the plugin will be setup automatically.
+#### kumactl >= 1.7.0
+
+If you use `kumactl install observability --components grafana,prometheus` with a version of kumactl >= 1.7.0 the plugin will be setup automatically.
+
+#### kumactl 1.3.0-1.6.*
+
+If you use `kumactl install metrics` with a version of kumactl 1.3.0-1.6.* the plugin will be setup automatically.
 
 ## Future features
 

--- a/tools/setup_k3d.sh
+++ b/tools/setup_k3d.sh
@@ -16,5 +16,5 @@ kubectl wait -n kuma-test --timeout=30s --for condition=Ready --all pods
 docker run  -p 3000:3000 -d  --network k3d-kuma-demo -e GF_DEFAULT_APP_MODE=development -v /Users/cmolter/code/kuma-datasource/dist:/var/lib/grafana/plugins --name=grafana grafana/grafana:8.2.2
 
 
-echo "grafana is expose on 3000, control-plane of 5681 and prometheus-server on 9090 interrupt to close these port-forward"
+echo "grafana is exposed on port 3000, control-plane on 5681 and prometheus-server on 9090 interrupt to close these port-forward"
 wait


### PR DESCRIPTION
Signed-off-by: slonka <slonka@users.noreply.github.com>

After this PR: https://github.com/kumahq/kuma/pull/4308/files we need to update docs accordingly. I updated:

- the namespaces to [mesh-observability](https://github.com/kumahq/kuma/pull/4308/files#diff-4097df65e73d6b3a2813df0ea3c87f15a6c43ba3aca9b73b3e60346758ef0344R152)
- urls pre/post fixes to match the new namespace

Related: 
- https://github.com/kumahq/kuma-website/issues/815
- https://github.com/kumahq/kuma-website/pull/830

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits) yes

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? yes
