### PR TITLE
feat: handle pagination when get service insights

### DIFF
--- a/pkg/plugin/client/client.go
+++ b/pkg/plugin/client/client.go
@@ -69,8 +69,8 @@ func (c *client) Hello(ctx context.Context) (*HelloResponse, error) {
 
 func (c *client) GetServiceInsights(ctx context.Context, mesh string) ([]ServiceInsight, error) {
 	var insights []ServiceInsight
-	path := fmt.Sprintf("%s/meshes/%s/service-insights", c.url, mesh)
-	next := &path
+	url := fmt.Sprintf("%s/meshes/%s/service-insights", c.url, mesh)
+	next := &url
 
 	for {
 		if next == nil {


### PR DESCRIPTION
Handle paginated responses when there is more service insights than are returned in one response

Closes: https://github.com/kumahq/kuma-grafana-datasource/issues/149

I tested it manually by spawning k3d cluster, installing kuma + demo + observability
![image](https://user-images.githubusercontent.com/11655498/185392899-bad16655-b5ab-4f4e-b04b-d53b47e64728.png)

taking the modified code out of this project (and adding `?size=1` to the end of the mesh insights url):
```go
package main

import (
	"context"
	"encoding/json"
	"fmt"
	"log"
	"net/http"
	"time"
)

type ServiceInsightResponse struct {
	Items []ServiceInsight `json:"items"`
	Total int              `json:"total"`
	Next  *string          `json:"next"`
}

type ServiceInsight struct {
	Type             string                    `json:"type"`
	Mesh             string                    `json:"mesh"`
	Name             string                    `json:"name"`
	CreationTime     time.Time                 `json:"creation_time"`
	ModificationTime time.Time                 `json:"modificationtime"`
	Status           string                    `json:"status"`
	Dataplanes       ServiceInsightsDpStatuses `json:"dataplanes"`
}

func (i ServiceInsightsDpStatuses) OnlinePercent() int {
	if i.Total == 0 {
		return 0
	}
	return (i.Online * 100) / i.Total
}

func (i ServiceInsightsDpStatuses) String() string {
	return fmt.Sprintf("%d/%d/%d", i.Online, i.Online, i.Total)
}

type ServiceInsightsDpStatuses struct {
	Online  int `json:"online"`
	Offline int `json:"offline"`
	Total   int `json:"total"`
}

type client struct {
	url    string
	client *http.Client
}

func NewClient(url string) (*client, error) {
	return &client{
		client: http.DefaultClient,
		url:    url,
	}, nil
}

func (c *client) GetServiceInsights(ctx context.Context, mesh string) ([]ServiceInsight, error) {
	var insights []ServiceInsight
	url := fmt.Sprintf("%s/meshes/%s/service-insights?size=1", c.url, mesh)
	next := &url

	for {
		if next == nil {
			break
		}

		log.Println("sending request", *next)

		var res = ServiceInsightResponse{}
		if err := c.get(ctx, *next, &res); err != nil {
			return nil, err
		}

		next = res.Next
		insights = append(insights, res.Items...)
	}

	return insights, nil
}

func (c *client) get(ctx context.Context, url string, out interface{}) error {
	req, err := http.NewRequest("GET", url, nil)
	if err != nil {
		return err
	}

	res, err := c.client.Do(req.WithContext(ctx))
	if err != nil {
		return err
	}

	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
		return err
	}

	return nil
}

func (c *client) getWithClientURLPrefix(ctx context.Context, path string, out interface{}) error {
	return c.get(ctx, c.url+path, out)
}

func main() {
	c, err := NewClient("http://localhost:5681")
	if err != nil {
		log.Fatalln(err)
	}

	insights, err := c.GetServiceInsights(context.Background(), "default")
	if err != nil {
		log.Fatalln(err)
	}

	for _, insight := range insights {
		log.Println(insight.Name, insight)
	}
}
```
Results:
```
2022/08/18 14:16:59 sending request http://localhost:5681/meshes/default/service-insights?size=1
2022/08/18 14:16:59 sending request http://localhost:5681/meshes/default/service-insights?offset=1&size=1
2022/08/18 14:16:59 sending request http://localhost:5681/meshes/default/service-insights?offset=2&size=1
2022/08/18 14:16:59 sending request http://localhost:5681/meshes/default/service-insights?offset=3&size=1
2022/08/18 14:16:59 demo-app_kuma-demo_svc_5000 {ServiceInsight default demo-app_kuma-demo_svc_5000 0001-01-01 00:00:00 +0000 UTC 2022-08-18 12:11:15 +0000 UTC online 1/1/1}
2022/08/18 14:16:59 grafana_mesh-observability_svc_80 {ServiceInsight default grafana_mesh-observability_svc_80 0001-01-01 00:00:00 +0000 UTC 2022-08-18 12:11:15 +0000 UTC offline 0/0/1}
2022/08/18 14:16:59 prometheus-server_mesh-observability_svc_80 {ServiceInsight default prometheus-server_mesh-observability_svc_80 0001-01-01 00:00:00 +0000 UTC 2022-08-18 12:11:15 +0000 UTC offline 0/0/1}
2022/08/18 14:16:59 redis_kuma-demo_svc_6379 {ServiceInsight default redis_kuma-demo_svc_6379 0001-01-01 00:00:00 +0000 UTC 2022-08-18 12:11:15 +0000 UTC online 1/1/1}
```

Did you sign your commit? [Instructions](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md#sign-your-commits): 👍 

Have you read [Contributing guidelines](https://github.com/kumahq/.github/blob/main/CONTRIBUTING.md)? 👍 
