### PR TITLE
Fixes set-output deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           if [ -f "Magefile.go" ]
           then
-            echo "::set-output name=has-backend::true"
+            echo "has-backend=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Setup Go environment


### PR DESCRIPTION
Fixes: 
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>
